### PR TITLE
Fix path handling in backup function

### DIFF
--- a/ezIncrementalBackup/cli.py
+++ b/ezIncrementalBackup/cli.py
@@ -96,8 +96,9 @@ def backup(type, compress, split_size, workers):
     now_str = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
     # 计算所有待打包文件的最近公共父目录
     def get_common_parent(paths):
-        from os.path import commonpath
-        return Path(commonpath(paths))
+        from os.path import commonpath, abspath
+        abs_paths = [os.path.abspath(p) for p in paths]
+        return Path(commonpath(abs_paths))
     if backup_type == 'full' or (backup_type == 'incremental' and not SNAPSHOT_PATH.exists()):
         if backup_type == 'incremental':
             click.echo('未检测到快照，自动切换为全量备份...')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ezIncrementalBackup",
-    version="1.0.3",
+    version="1.0.4",
     packages=find_packages(),
     install_requires=[
         'click',


### PR DESCRIPTION
Updated `get_common_parent` in `cli.py` to use absolute paths for calculating the common parent directory, ensuring correct behavior. Also bumped the package version in `setup.py` from 1.0.3 to 1.0.4.