### PR TITLE
fix: 7z多线程支持

### DIFF
--- a/ezIncrementalBackup/cli.py
+++ b/ezIncrementalBackup/cli.py
@@ -136,7 +136,7 @@ def backup(type, compress, split_size, workers):
                         continue
                     all_files.append((Path(root) / file).as_posix())
             archive_path = Path(target_dir) / f'full_{now_str}.7z'
-            parts = compress_files_with_split(all_files, archive_path, split_size_mb, base_dir=source_dir)
+            parts = compress_files_with_split(all_files, archive_path, split_size_mb, base_dir=source_dir , workers=workers)
             click.echo(f'生成分卷: {parts}')
         else:
             click.echo('未启用压缩，直接复制源文件到目标目录...')

--- a/ezIncrementalBackup/cli_wizard.py
+++ b/ezIncrementalBackup/cli_wizard.py
@@ -166,11 +166,15 @@ def backup(btype):
         workers_input = questionary.text(f"请输入进程数（留空=自动，当前配置={workers}）:").ask()
         if workers_input:
             workers = workers_input
+        else:
+            workers = int(os.cpu_count() * 0.75) % 100
+            print(f"自动设置进程数为: {workers} (75%的cpu核心数)")
     cmd = [sys.executable, "-m", "ezIncrementalBackup.cli", "backup", "--type", btype]
     if workers:
         cmd += ["--workers", str(workers)]
     subprocess.run(cmd, check=True)
     print("备份完成！")
+    return True
 
 def is_excluded(item, source_dir, exclude_dirs):
     rel_path = os.path.relpath(item, source_dir).replace("\\", "/")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ezIncrementalBackup",
-    version="1.2.0RC1",
+    version="1.2.0RC2",
     packages=find_packages(),
     install_requires=[
         'click',


### PR DESCRIPTION
在压缩过程中引入'workers'参数以启用7z的多线程处理。更新了命令行界面和向导程序，允许用户指定或自动计算线程数量。已将setup.py中的版本号升级至1.2.0RC2。

Introduced a 'workers' parameter to enable multi-threading in the compression process using 7z. Updated CLI and wizard to allow users to specify or auto-calculate the number of threads. Bumped the version to 1.2.0RC2 in setup.py.